### PR TITLE
Add CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(zip_iterables VERSION 1.0.0 LANGUAGES CXX)
+
+add_library(zip_iterables INTERFACE zip_iterables.hpp)
+add_library(zip_iterables::zip_iterables ALIAS zip_iterables)
+
+target_include_directories(zip_iterables INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/README.md
+++ b/README.md
@@ -230,5 +230,25 @@ nest: (1,2,a,{1,1}) (3,4,b,{2,2}) (5,6,c,{3,3})
 ```
 
 
+## CMake
+To add to a CMake project, the package must be included in the build:
+
+- As subdirectory:
+```cmake
+add_subdirectory(zip_iterables)
+```
+
+- With [CPM](https://github.com/cpm-cmake/CPM.cmake):
+```cmake
+CPMAddPackage("gh:beanpudding/zip_iterables#master")
+```
+
+And then depended on:
+
+```cmake
+target_link_libraries(<your-target-here> PRIVATE zip_iterables::zip_iterables)
+```
+
+
 ## License
 Open sourced under [MIT license](http://opensource.org/licenses/MIT), the terms of which can be read here - [LICENSE](./LICENSE).


### PR DESCRIPTION
It might seem silly to add CMake to a library this small, but I personally use [CPM](https://github.com/cpm-cmake/CPM.cmake) for my dependencies, and CPM requires projects to have working CMake support. This is an unintrusive modification -- you can keep using this library however you already are, but it will now be useable with modern CMake and CPM. I updated the README with instructions on how to use the new functionality, but I'd also recommend adding a new tag "v1.0.0" so that CPM can do proper versioning, i.e. `CPMAddPackage(GITHUB_REPOSITORY beanpudding/zip_iterables VERSION 1.0.0)` rather than specifying commits or branches, i.e. `CPMAddPackage("gh:beanpudding/zipiterables#master")`.

Honestly, I made this change for myself, but thought I'd pull request it in case it could help anyone else.